### PR TITLE
Add docker compose 

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,11 @@ You should configure the apsd with callsign, APRS-IS servers, etc. through the w
 
 The container will put app data /var/lib/polaric in a volume to allow Docker to preserve data between subsequent runs. 
 
+## docker compose
+
+A docker compose file has been added so it should be easier to deploy this solution. 
+To build and deploy the aprsd and webapp2 container:
+
+```sh
+docker compose up
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: "3.9"
+services:
+  webapp2:
+    build: webapp2
+    ports:
+      - "8080:80"
+  aprsd:
+    build: aprsd
+    ports:
+      - "8081:8081"
+

--- a/webapp2/config.js
+++ b/webapp2/config.js
@@ -12,7 +12,7 @@
  * Uncomment to use aprs.no as a backend. 
  * Default is to use the location of the webapp. 
  */
-// SERVER("https://aprs.no");
+SERVER("http://localhost:8081");
 
 
 /* 


### PR DESCRIPTION
This PR is related to #1 and does 3 things:

* Adds docker-compose.yml, which makes it possible to run `docker compose` to deploy polaric-server. Note that aprsd still lives on `http://localhost:8081`, however webapp2 now lives on `http://localhost:8080`. webapp2 is configured to speak with aprsd as usual.
* Updates README.md about this
* Changes the default backend server to `http://localhost:8081` to make webapp2 talk with aprsd. 